### PR TITLE
Remove Package-Requires header

### DIFF
--- a/term-run.el
+++ b/term-run.el
@@ -3,7 +3,6 @@
 ;; Author: 10sr <8.slashes+el [at] gmail [dot] com>
 ;; URL: https://github.com/10sr/term-run-el
 ;; Version: 0.1
-;; Package-Requires: ((term "0"))
 ;; Keywords: utility shell command term-mode
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
There is no installable package called `term`, so this line would make this
code uninstallable on Emacs 23, where package.el doesn't know about built-in
packages.
