### PR TITLE
term-run-shell-command: Generate buf name from COMMAND when C-u is given

### DIFF
--- a/term-run.el
+++ b/term-run.el
@@ -124,7 +124,9 @@ This function returns the buffer where the process starts running."
                                          'term-run-shell-command-history)
                      current-prefix-arg))
   (let ((buf (if new-buffer-p
-                 (generate-new-buffer "*Term-Run Shell Command*")
+                 (let ((cmdname (car (split-string command))))
+                   (generate-new-buffer (format "*Term-Run Shell Command<%s>*"
+                                                cmdname)))
                (get-buffer-create "*Term-Run Shell Command*")))
         (shell (or explicit-shell-file-name
                    shell-file-name


### PR DESCRIPTION
例えば、 `ssh remote` とやると、バッファの名前は `*Term-Run Shell Command<ssh>` になったりする
